### PR TITLE
.github: Include elfs in artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,8 @@ jobs:
           path: |
             ${{ github.workspace }}/build/zephyr/merged.hex
             ${{ github.workspace }}/build/zephyr/dfu_application.zip
+            ${{ github.workspace }}/build/zephyr/zephyr.elf
+            ${{ github.workspace }}/build/zephyr/zephyr.map
 
   release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This makes it possible to load the ELF files in GDB when debugging.