### PR TITLE
.github: Run CI against Pull Request commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Fetch Toolchain + NRF & ANT SDK
         if: steps.cache-ncs-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
Currently when a pull request is opened the CI builds the current master branch. This means you aren't testing the new code and the build artifacts don't include the new code either.

This commit ensures you build the new code when a PR is submitted.

**Note** this does expose some potential security issues. You probably want to disable running the CI automatically, so you can at least verify that future PRs aren't just printing your API keys or something sneaky like that. You have a [comment about that already](https://github.com/bitmeal/sks_airspy_ant_community_fw/blob/master/.github/workflows/ci.yaml#L10), but don't appear to have enabled the setting.